### PR TITLE
Update getting-paid.md

### DIFF
--- a/handbook/workflows/getting-paid.md
+++ b/handbook/workflows/getting-paid.md
@@ -4,10 +4,23 @@ Each project has preset payment checkpoints for distributing compensation to bui
 
 1. At project kickoff, builders **enter claims in the** [**budget spreadsheet**](https://sheet.zoho.com/sheet/open/a4p9k334be0a1097242a3b83d72f227695a48) based on time commitments and task allocations.
 2. As each payment checkpoint approaches, builders **adjust claims** based on actual work done.
-3. Within 5 days of the checkpoint, **post** [**payment proposals**](https://airtable.com/shrSsOJJUoM6N6IKL) to the DAO.
+3. Within 5 days of the checkpoint, **post payment proposals** to the DAO.
 
 {% hint style="info" %}
 The execution lead ensures that builders enter and adjust claims on time. The lead can also submit payment proposals on behalf of builders if they prefer.
+{% endhint %}
+
+{% hint style="success" %}
+### How to post payment
+We plan to streamline this!
+
+1. **Post** [**payment request**](https://airtable.com/shrSsOJJUoM6N6IKL) via the Airtable form. (Make sure claims are adjusted - double check with people before putting the proposal in.)
+2. **Post payment proposal** in Alchemy
+* Title field: Project Name - Milestone # - Builder Name
+* Description: link to the budget spreadsheet
+* URL: link to the payment request record in airtable. To find this, go to Transactions in Airtable, the Compensation view, and right click on the invoice ID. 
+* Recipient: To find the builder’s ETH address, go to the Entities tab in Airtable and click on the Builder view.
+* Enter the amount of xDAI to be paid, and DXRG if the builder is claiming payment partially in dOrg’s token.
 {% endhint %}
 
 ## Dealing with Conflict


### PR DESCRIPTION
Handbook adjusted as interim step for issue #44 - Improve builder payment proposal flow
--removed hyper link on post payment proposals and added green box with details
--Question: Does the payment request record URL display when someone submits their request? Or do you have to go find it in Airtable?