### PR TITLE
Amend DSP-4 landing page budget

### DIFF
--- a/DSPs/004-Landing-Page.md
+++ b/DSPs/004-Landing-Page.md
@@ -30,11 +30,12 @@ Our website needs to be up to date with our portfolio and how we work in order t
 
 ### Builders
 - Roberto: design contest lead
-- Ben: implementation lead
+- Ben: coordination lead
+- Kris: implementation
 - Open to help from all other builders on design contest and implementation
 
 ## Cost
 
-Up to $4,000
+Up to $9,000
 - $2,000 - Design ($1780 design contest + $220 internal work)
-- $2,000 - Implementation (internal)
+- $7,000 + 1,000 DXRG - Implementation (internal)


### PR DESCRIPTION
The team has done an excellent job at implementing [the landing page](https://polished-fog-7734.on.fleek.co/#/) and there's only a little [work left to do](https://github.com/dOrgTech/landing-page-v2/projects/3) before we reach an MVP.
Unfortunately, the team has gone over the estimated hours substantially due to poor coordination, lack of resources, and inexperience. 
So, we are proposing a fixed amended budget with an estimated hourly rate of $50/hr which is proportionate to the lower end of [a freelance junior front end developer's rate](https://www.codementor.io/freelance-rates/front-end-developers). See [the budget sheet](https://docs.google.com/spreadsheets/d/1mwYhzTNXSytzVtACZLu1V_EVTfjPKhGfHu-KhnBFESk/edit?usp=sharing) for full details.
Feel free to contact me directly with any questions.